### PR TITLE
Ensure RPC method name is always present in logs

### DIFF
--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -367,10 +367,10 @@ func syncRequestTyped[T any](ctx context.Context, rc *RPCClient, rpcReq *RPCRequ
 		rpcTraceID = fmt.Sprintf("%s->%s", rpcReq.ID, rpcTraceID)
 	}
 
-	log.L(ctx).Debugf("RPC[%s] --> %s", rpcTraceID, rpcReq.Method)
+	log.L(ctx).Debugf("RPC[%s] --> %s", rpcTraceID, method)
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		jsonInput, _ := json.Marshal(rpcReq)
-		log.L(ctx).Tracef("RPC[%s] INPUT: %s", rpcTraceID, jsonInput)
+		log.L(ctx).Tracef("RPC[%s] --> %s: INPUT: %s", rpcTraceID, method, jsonInput)
 	}
 	rpcStartTime := time.Now()
 	res, httpErr := rc.client.R().
@@ -384,14 +384,14 @@ func syncRequestTyped[T any](ctx context.Context, rc *RPCClient, rpcReq *RPCRequ
 	rpcRes.ID = rpcReq.ID
 	if httpErr != nil {
 		httpErr = i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, httpErr)
-		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", rpcTraceID, httpErr)
+		log.L(ctx).Errorf("RPC[%s] <-- %s: ERROR: %s", rpcTraceID, method, httpErr)
 		rpcRes.Error = &RPCError{Code: int64(RPCCodeInternalError), Message: httpErr.Error()}
 		record(statusTransportError)
 		return rpcRes, 0, httpErr
 	}
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		jsonOutput, _ := json.Marshal(rpcRes)
-		log.L(ctx).Tracef("RPC[%s] OUTPUT: %s", rpcTraceID, jsonOutput)
+		log.L(ctx).Tracef("RPC[%s] <-- %s: OUTPUT: %s", rpcTraceID, method, jsonOutput)
 	}
 	// JSON/RPC allows errors to be returned with a 200 status code, as well as other status codes
 	if res.IsError() || rpcRes.Error != nil && rpcRes.Error.Code != 0 {
@@ -403,11 +403,11 @@ func syncRequestTyped[T any](ctx context.Context, rc *RPCClient, rpcReq *RPCRequ
 			errLog = string(res.Body())
 			rpcMsg = i18n.NewError(ctx, signermsgs.MsgRPCRequestFailed, res.Status()).Error()
 		}
-		log.L(ctx).Errorf("RPC[%s] <-- [%d]: %s", rpcTraceID, res.StatusCode(), errLog)
+		log.L(ctx).Errorf("RPC[%s] <-- %s: [%d]: %s", rpcTraceID, method, res.StatusCode(), errLog)
 		record(statusFromHTTPCode(res.StatusCode()))
 		return rpcRes, res.StatusCode(), errors.New(rpcMsg)
 	}
-	log.L(ctx).Infof("RPC[%s] <-- %s [%d] OK (%.2fms)", rpcTraceID, rpcReq.Method, res.StatusCode(), float64(time.Since(rpcStartTime))/float64(time.Millisecond))
+	log.L(ctx).Infof("RPC[%s] <-- %s: [%d] OK (%.2fms)", rpcTraceID, method, res.StatusCode(), float64(time.Since(rpcStartTime))/float64(time.Millisecond))
 	record(statusFromHTTPCode(res.StatusCode()))
 	return rpcRes, res.StatusCode(), nil
 }

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -347,13 +347,13 @@ func (rc *wsRPCClient) sendRPC(ctx context.Context, reqID string, rpcReq *RPCReq
 	if err == nil {
 		log.L(ctx).Debugf("RPC[%s] --> %s", reqID, rpcReq.Method)
 		if logrus.IsLevelEnabled(logrus.TraceLevel) {
-			log.L(ctx).Tracef("RPC[%s] INPUT: %s", reqID, jsonInput)
+			log.L(ctx).Tracef("RPC[%s] --> %s: INPUT: %s", reqID, rpcReq.Method, jsonInput)
 		}
 		err = rc.client.Send(ctx, jsonInput)
 	}
 	if err != nil {
 		rpcErr := NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgRPCRequestFailed, err)
-		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, err)
+		log.L(ctx).Errorf("RPC[%s] <-- %s: ERROR: %s", reqID, rpcReq.Method, err)
 		return rpcErr
 	}
 	return nil
@@ -383,16 +383,16 @@ func (rc *wsRPCClient) waitResponse(ctx context.Context, result interface{}, req
 	case rpcRes = <-resChannel:
 	case <-ctx.Done():
 		rpcErr := NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgRequestCanceledContext, reqID)
-		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, rpcErr.Error())
+		log.L(ctx).Errorf("RPC[%s] <-- %s: ERROR: %s", reqID, rpcReq.Method, rpcErr.Error())
 		recordRPCRequest(ctx, rpcReq.Method, statusCanceled, false, time.Since(start))
 		return rpcErr
 	}
 	if rpcRes.Error != nil && rpcRes.Error.Code != 0 {
-		log.L(ctx).Errorf("RPC[%s] <-- ERROR: %s", reqID, rpcRes.Message())
+		log.L(ctx).Errorf("RPC[%s] <-- %s: ERROR: %s", reqID, rpcReq.Method, rpcRes.Message())
 		recordRPCRequest(ctx, rpcReq.Method, statusFromRPCError(rpcRes.Error.Code), false, time.Since(start))
 		return rpcRes.Error
 	}
-	log.L(ctx).Infof("RPC[%s] <-- %s OK (%s)", reqID, rpcReq.Method, time.Since(start))
+	log.L(ctx).Infof("RPC[%s] <-- %s: OK (%s)", reqID, rpcReq.Method, time.Since(start))
 	if result != nil {
 		if err := unmarshalRPCResult(rpcRes.Result, &result); err != nil {
 			err = i18n.NewError(ctx, signermsgs.MsgResultParseFailed, result, err)
@@ -414,18 +414,18 @@ func (rc *wsRPCClient) handleSubscriptionNotification(ctx context.Context, rpcRe
 		_ = json.Unmarshal(rpcRes.Params.Bytes(), &subParams)
 	}
 	if len(subParams.Subscription) == 0 {
-		log.L(ctx).Warnf("RPC[%s] <-- Unable to extract subscription id from notification: %s", rpcRes.ID.AsString(), rpcRes.Params)
+		log.L(ctx).Warnf("RPC[%s] <-- %s: Unable to extract subscription id from notification: %s", rpcRes.ID.AsString(), rpcRes.Method, rpcRes.Params)
 		return
 	}
 
 	s := rc.getActiveSub(subParams.Subscription)
 	if s == nil {
-		log.L(ctx).Warnf("RPC[%s] <-- Notification for unknown subscription '%s'", rpcRes.ID.AsString(), subParams.Subscription)
+		log.L(ctx).Warnf("RPC[%s] <-- %s: Notification for unknown subscription '%s'", rpcRes.ID.AsString(), rpcRes.Method, subParams.Subscription)
 		return
 	}
 
 	// This is a notification that should match an active subscription
-	log.L(ctx).Debugf("RPC[%s] <-- Notification for subscription %s (serverId=%s)", rpcRes.ID.AsString(), s.localID, s.currentSubID)
+	log.L(ctx).Debugf("RPC[%s] <-- %s: Notification for subscription %s (serverId=%s)", rpcRes.ID.AsString(), rpcRes.Method, s.localID, s.currentSubID)
 	select {
 	case s.notifications <- &RPCSubscriptionNotification{
 		CurrentSubID: s.currentSubID,
@@ -433,7 +433,7 @@ func (rc *wsRPCClient) handleSubscriptionNotification(ctx context.Context, rpcRe
 	}:
 	case <-s.ctx.Done():
 		// The subscription has been unsubscribed, or we're closing
-		log.L(ctx).Warnf("RPC[%s] <-- Received subscription event after unsubscribe/close %s (serverId=%s)", rpcRes.ID.AsString(), s.localID, s.currentSubID)
+		log.L(ctx).Warnf("RPC[%s] <-- %s: Received subscription event after unsubscribe/close %s (serverId=%s)", rpcRes.ID.AsString(), rpcRes.Method, s.localID, s.currentSubID)
 	}
 }
 
@@ -441,7 +441,7 @@ func (rc *wsRPCClient) handleSubscriptionConfirm(ctx context.Context, inflightSu
 	resChl := inflightSub.newSubResponse
 	inflightSub.newSubResponse = nil // we only dispatch once (it's only new once, on reconnect it's old and there's nobody to tell if we fail)
 	if rpcRes.Error != nil && rpcRes.Error.Code != 0 {
-		log.L(ctx).Warnf("RPC[%s] <-- Error creating subscription %s: %s", rpcRes.ID.AsString(), inflightSub.localID, rpcRes.Params)
+		log.L(ctx).Warnf("RPC[%s] <-- %s: Error creating subscription %s: %s", rpcRes.ID.AsString(), rpcRes.Method, inflightSub.localID, rpcRes.Params)
 		if resChl != nil {
 			resChl <- rpcRes.Error
 		}
@@ -452,13 +452,13 @@ func (rc *wsRPCClient) handleSubscriptionConfirm(ctx context.Context, inflightSu
 		_ = json.Unmarshal(rpcRes.Result.Bytes(), &subscriptionID)
 	}
 	if len(subscriptionID) == 0 {
-		log.L(ctx).Warnf("RPC[%s] <-- Unable to extract subscription id from eth_subscribe response: %s", rpcRes.ID.AsString(), rpcRes.Params)
+		log.L(ctx).Warnf("RPC[%s] <-- %s: Unable to extract subscription id from eth_subscribe response: %s", rpcRes.ID.AsString(), rpcRes.Method, rpcRes.Params)
 		if resChl != nil {
 			resChl <- NewRPCError(ctx, RPCCodeInternalError, signermsgs.MsgSubscribeResponseInvalid)
 		}
 		return
 	}
-	log.L(ctx).Infof("Subscribed %s with server subscription ID '%s'", inflightSub.localID, subscriptionID)
+	log.L(ctx).Infof("RPC[%s] <-- %s: Subscribed %s with server subscription ID '%s'", rpcRes.ID.AsString(), rpcRes.Method, inflightSub.localID, subscriptionID)
 	rc.addActiveSub(inflightSub, subscriptionID)
 	// all was good, if someone is waiting to be told, notify them
 	if resChl != nil {
@@ -498,7 +498,7 @@ func (rc *wsRPCClient) receiveLoop(ctx context.Context) {
 			case inflightCall != nil:
 				rc.deliverCallResponse(ctx, inflightCall, &rpcRes)
 			default:
-				log.L(ctx).Warnf("RPC[%s] <-- Received unexpected RPC response: %+v", rpcRes.ID.AsString(), rpcRes)
+				log.L(ctx).Warnf("RPC[%s] <-- %s: Received unexpected RPC response: %+v", rpcRes.ID.AsString(), rpcRes.Method, rpcRes)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
RPC logs used the method name inconsistently. Some lines only had it in the INFO-level summary, so if a deployment ran with a higher log level (e.g. only WARN/ERROR), it was hard to tell which method a given error or trace line belonged to.

- `backend.go`: pass `method` into the debug, trace, and error log lines for the sync HTTP request path.
- `wsbackend.go`: add `rpcReq.Method` / `rpcRes.Method` to the WS send, error, subscription, and notification log lines.