### PR TITLE
feat(rpcbackend): Metrics for measuring delay / timeouts introduced by the concurrency limiter

### DIFF
--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -142,14 +142,23 @@ func (r *RPCResponseTyped[T]) Message() string {
 // as raw bytes in a fftypes.JSONAny for a second json.Unmarshal by the caller.
 type RPCResponse = RPCResponseTyped[*fftypes.JSONAny]
 
+// reserveConcurrencySlot blocks until an outbound concurrency slot is available, the context is
+// cancelled / times out. The returned function must be called to release the slot.
 func (rc *RPCClient) reserveConcurrencySlot(ctx context.Context, id any) (func(), *RPCError) {
 	if rc.concurrencySlots == nil {
 		return func() {}, nil
 	}
+	start := time.Now()
 	select {
 	case rc.concurrencySlots <- true:
+		waited := time.Since(start)
+		recordConcurrencySlotWait(ctx, waited)
+		log.L(ctx).Tracef("RPC[%v] acquired 1 of %d concurrency slots after %.3fms", id, cap(rc.concurrencySlots), float64(waited)/float64(time.Millisecond))
 		return func() { <-rc.concurrencySlots }, nil
 	case <-ctx.Done():
+		waited := time.Since(start)
+		recordConcurrencySlotWaitFailed(ctx, waited)
+		log.L(ctx).Warnf("RPC[%v] gave up waiting for 1 of %d concurrency slots after %.3fms", id, cap(rc.concurrencySlots), float64(waited)/float64(time.Millisecond))
 		err := i18n.NewError(ctx, signermsgs.MsgRequestCanceledContext, id)
 		return nil, &RPCError{Code: int64(RPCCodeInternalError), Message: err.Error()}
 	}

--- a/pkg/rpcbackend/backend_bench_test.go
+++ b/pkg/rpcbackend/backend_bench_test.go
@@ -1,0 +1,67 @@
+// Copyright © 2026 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcbackend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger-firefly/common/pkg/metric"
+)
+
+func benchmarkReserveConcurrencySlot(b *testing.B, slots int64, metricsOn, parallel bool) {
+	rpcMetrics = nil
+	if metricsOn {
+		EnableMetrics(context.Background(), metric.NewPrometheusMetricsRegistry(b.Name()))
+		b.Cleanup(func() { rpcMetrics = nil })
+	}
+	rc := &RPCClient{concurrencySlots: make(chan bool, slots)}
+	ctx := context.Background()
+	acquireRelease := func() {
+		returnSlot, rpcErr := rc.reserveConcurrencySlot(ctx, "bench")
+		if rpcErr != nil {
+			b.Fatal(rpcErr)
+		}
+		returnSlot()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	if parallel {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				acquireRelease()
+			}
+		})
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		acquireRelease()
+	}
+}
+
+func BenchmarkReserveConcurrencySlotUncontendedMetricsOff(b *testing.B) {
+	benchmarkReserveConcurrencySlot(b, 50, false, false)
+}
+
+func BenchmarkReserveConcurrencySlotUncontendedMetricsOn(b *testing.B) {
+	benchmarkReserveConcurrencySlot(b, 50, true, false)
+}
+
+func BenchmarkReserveConcurrencySlotContendedMetricsOn(b *testing.B) {
+	benchmarkReserveConcurrencySlot(b, 1, true, true)
+}

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hyperledger-firefly/common/pkg/ffresty"
 	"github.com/hyperledger-firefly/common/pkg/fftypes"
@@ -650,4 +651,31 @@ func TestSyncRequestConcurrency(t *testing.T) {
 	close(blocked)
 	<-bgDone
 
+}
+
+func TestReserveConcurrencySlotWaitsForRelease(t *testing.T) {
+	ctx := context.Background()
+	rb := &RPCClient{concurrencySlots: make(chan bool, 1)}
+
+	release, rpcErr := rb.reserveConcurrencySlot(ctx, "first")
+	assert.Nil(t, rpcErr)
+	assert.Equal(t, 1, len(rb.concurrencySlots))
+
+	queued := make(chan struct{})
+	go func() {
+		defer close(queued)
+		release2, rpcErr := rb.reserveConcurrencySlot(ctx, "second")
+		assert.Nil(t, rpcErr)
+		release2()
+	}()
+
+	// The second reservation can only complete once the first slot is returned
+	select {
+	case <-queued:
+		t.Fatal("second reservation completed while the only slot was held")
+	case <-time.After(10 * time.Millisecond):
+	}
+	release()
+	<-queued
+	assert.Equal(t, 0, len(rb.concurrencySlots))
 }

--- a/pkg/rpcbackend/metrics.go
+++ b/pkg/rpcbackend/metrics.go
@@ -32,6 +32,9 @@ const (
 	metricHistogramRPCRequestDurationMs = "rpc_request_duration_milliseconds"
 	metricHistogramRPCBatchSize         = "rpc_batch_size"
 
+	metricSummaryConcurrencySlotWaitMs     = "concurrency_slot_wait_milliseconds"
+	metricCounterConcurrencySlotWaitFailed = "concurrency_slot_wait_failed_total"
+
 	labelMethod = "method"
 	labelStatus = "status"
 	labelBatch  = "batch"
@@ -94,6 +97,24 @@ func EnableMetrics(ctx context.Context, metricsRegistry metric.MetricsRegistry) 
 	rpcMetrics.NewCounterMetricWithLabels(ctx, metricCounterRPCRequestTotal, "Total number of RPC backend requests", rpcRequestLabels, false)
 	rpcMetrics.NewHistogramMetricWithLabels(ctx, metricHistogramRPCRequestDurationMs, "Duration of RPC backend requests in milliseconds", rpcDurationMsBuckets, rpcDurationLabels, false)
 	rpcMetrics.NewHistogramMetric(ctx, metricHistogramRPCBatchSize, "Number of RPC calls per HTTP batch request", rpcBatchSizeBuckets, false)
+
+	rpcMetrics.NewSummaryMetric(ctx, metricSummaryConcurrencySlotWaitMs, "Time spent waiting for a concurrency slot in milliseconds", false)
+	rpcMetrics.NewCounterMetric(ctx, metricCounterConcurrencySlotWaitFailed, "Total number of requests that gave up waiting for a concurrency slot", false)
+}
+
+func recordConcurrencySlotWait(ctx context.Context, waited time.Duration) {
+	if rpcMetrics == nil {
+		return
+	}
+	rpcMetrics.ObserveSummaryMetric(ctx, metricSummaryConcurrencySlotWaitMs, durationMs(waited), nil)
+}
+
+func recordConcurrencySlotWaitFailed(ctx context.Context, waited time.Duration) {
+	if rpcMetrics == nil {
+		return
+	}
+	rpcMetrics.IncCounterMetric(ctx, metricCounterConcurrencySlotWaitFailed, nil)
+	rpcMetrics.ObserveSummaryMetric(ctx, metricSummaryConcurrencySlotWaitMs, durationMs(waited), nil)
 }
 
 func recordRPCRequest(ctx context.Context, method, status string, batch bool, duration time.Duration) {

--- a/pkg/rpcbackend/metrics_test.go
+++ b/pkg/rpcbackend/metrics_test.go
@@ -114,3 +114,26 @@ func TestStatusHelpers(t *testing.T) {
 	assert.Equal(t, "unknown", rpcMethodLabel(""))
 	assert.Equal(t, "eth_chainId", rpcMethodLabel("eth_chainId"))
 }
+
+func TestRecordConcurrencyNoOpWhenDisabled(t *testing.T) {
+	defer resetRPCMetrics()
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() {
+		recordConcurrencySlotWait(ctx, time.Millisecond)
+		recordConcurrencySlotWaitFailed(ctx, time.Millisecond)
+	})
+}
+
+func TestRecordConcurrencyEmitWhenEnabled(t *testing.T) {
+	defer resetRPCMetrics()
+	ctx := context.Background()
+	mr := metric.NewPrometheusMetricsRegistry("test_rpcbackend_concurrency")
+	EnableMetrics(ctx, mr)
+
+	assert.NotPanics(t, func() {
+		recordConcurrencySlotWait(ctx, 0)
+		recordConcurrencySlotWait(ctx, 250*time.Millisecond)
+		recordConcurrencySlotWaitFailed(ctx, 30*time.Second)
+	})
+}


### PR DESCRIPTION
The concurrency limiter can be critical to ensuring an individual RPC client behaves within reasonable bounds of a downstream RPC endpoint (regardless of the underlying HTTP connections limit or throttling that might also be configured).

Like the K8s client's throttling delay metrics - measuring the delay its introducing when the user of the RPC client is under load is helpful for diagnosing whether its unnecessarily slowing things relative to whether if its protecting the downstream / preventing errors.

These metrics will help us to visualize the throttling, and the benchmarks codify the expected overhead of the instrumentation and the limiter itself. 